### PR TITLE
Add lang attribute to html-header.twig

### DIFF
--- a/themes/climatestrike/templates/html-header.twig
+++ b/themes/climatestrike/templates/html-header.twig
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="{{ site.lang }}">
     <head>
         <meta charset="{{ site.charset }}" />
         {% block title %}


### PR DESCRIPTION
added `{{ site.lang }}` to the `lang` attribute of the html tag to fix accessibility issues